### PR TITLE
fix: checkboxes now display

### DIFF
--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -7,9 +7,9 @@
 /*
     Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
     - The "symbol *" part is to solve Firefox SVG sprite bug
-    - The "html" attribute is exclud, because otherwise a bug in Chrome breaks the CSS hyphens property (https://github.com/elad2412/the-new-css-reset/issues/36)
+    - The "html" attribute is exclude, because otherwise a bug in Chrome breaks the CSS hyphens property (https://github.com/elad2412/the-new-css-reset/issues/36)
  */
-*:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
+*:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *):not(input[type="checkbox"])) {
     all: unset;
     display: revert;
 }


### PR DESCRIPTION
Checkboxes now display properly.
Added :not(input[type="checkbox"]) to reset.css to exclude checkboxes from having their styles unset and reverted.